### PR TITLE
Update address-form.html.twig

### DIFF
--- a/src/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Resources/views/storefront/component/address/address-form.html.twig
@@ -164,8 +164,7 @@
                 {% block component_address_form_zipcode_city %}
                     {{ parent() }}
                 {% endblock %}
-            </div>
-            <div class="row g-2">
+
                 {% block component_address_form_additional_field1 %}
                     {{ parent() }}
                 {% endblock %}
@@ -174,7 +173,6 @@
                     {{ parent() }}
                 {% endblock %}
             </div>
-
             <div class="row g-2">
                 {% block component_address_form_phone_number %}
                     {{ parent() }}


### PR DESCRIPTION
Currently the address form for NL is broken when additionalField1 / additionalField2 is configured to be shown and address check is enabled. Caused by this commit: https://github.com/postnl/shopware/commit/9b1d4f78e9d1d922ee6b2eac4fd02e7b7f95bfe5

Plugin v1.2.3 (also broken in 2.0.0):
![image](https://github.com/postnl/shopware/assets/26538915/a473d767-540e-44bd-a68e-c595d386053b)

![image](https://github.com/postnl/shopware/assets/26538915/9bbeea02-715a-4b68-80c8-46747a47e8b8)


Plugin v3.0.0:
![image](https://github.com/postnl/shopware/assets/26538915/d4ea1332-c862-4d5e-9ecc-3a744bd9ebbb)

![image](https://github.com/postnl/shopware/assets/26538915/c9d72896-20d5-4326-b697-f205d9da2719)

As you can see in v3.0.0 the additionalFields are moved into a div that isn't hidden, so the field is shown in the address form which doesn't make sense.

This PR moves the additionalFields so when the address check is active, these fields aren't shown, just like before. 
