### PR TITLE
Fix pickup points + add locationCode as custom field

### DIFF
--- a/src/Subscriber/ConversionSubscriber.php
+++ b/src/Subscriber/ConversionSubscriber.php
@@ -122,6 +122,11 @@ class ConversionSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $attributes = $this->attributeFactory->createFromEntity($cart->getDeliveries()->first()->getShippingMethod(), $event->getContext());
+        if($attributes->getDeliveryType() === DeliveryType::PICKUP) {
+            return;
+        }
+
         $deliveryAddress = $cart->getDeliveries()->first()->getLocation()->getAddress();
 
         $context = $event->getSalesChannelContext();
@@ -356,7 +361,7 @@ class ConversionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (is_null($attributes->getDeliveryType())) {
+        if ($attributes->getDeliveryType() === null || $attributes->getDeliveryType() === DeliveryType::PICKUP) {
             return;
         }
 
@@ -403,6 +408,12 @@ class ConversionSubscriber implements EventSubscriberInterface
             );
 
             $convertedCart = $this->setPickupPointAsDeliveryAddresses($convertedCart, $pickupPoint, $event->getContext());
+            $convertedCart['customFields'][Defaults::CUSTOM_FIELDS_KEY] = array_merge_recursive(
+                $convertedCart['customFields'][Defaults::CUSTOM_FIELDS_KEY] ?? [],
+                [
+                    'pickupPointLocationCode' => $cartData->get('pickupPointLocationCode')
+                ]
+            );
         }
 
         $event->setConvertedCart($convertedCart);


### PR DESCRIPTION
Currently pickup points are broken:

```
Error:
Call to a member function format() on null

  at vendor/postnl/shopware6/src/Component/PostNL/Service/RequestBuilder/Rest/DeliveryDateServiceRestRequestBuilderDecorator.php:23
  at PostNL\Shopware6\Component\PostNL\Service\RequestBuilder\Rest\DeliveryDateServiceRestRequestBuilderDecorator->buildGetSentDateRequest(object(GetSentDateRequest))
     (vendor/firstred/postnl-api-php/src/Service/DeliveryDateService.php:180)
  at Firstred\PostNL\Service\DeliveryDateService->getSentDate(object(GetSentDateRequest))
     (vendor/firstred/postnl-api-php/src/PostNL.php:2040)
  at Firstred\PostNL\PostNL->getSentDate(object(GetSentDateRequest))
     (vendor/postnl/shopware6/src/Service/Shopware/DeliveryDateService.php:41)
  at PostNL\Shopware6\Service\Shopware\DeliveryDateService->getSentDate(object(SalesChannelContext), object(GetSentDate))
     (vendor/postnl/shopware6/src/Subscriber/ConversionSubscriber.php:168)
  at PostNL\Shopware6\Subscriber\ConversionSubscriber->addSendDate(object(CartConvertedEvent)
```

and

```
Error:
Call to a member function format() on null

  at vendor/postnl/shopware6/src/Subscriber/ConversionSubscriber.php:370
  at PostNL\Shopware6\Subscriber\ConversionSubscriber->addDeliveryTypeData(object(CartConvertedEvent), 'Shopware\\Core\\Checkout\\Cart\\Order\\CartConvertedEvent', object(TraceableEventDispatcher))
```

Pickup points don't have a delivery/shipping date so this should not be added to the order. 

Also the pickupPointLocationCode isn't added as customField to the order, I've added that. 